### PR TITLE
データ変換エラーが解決できない

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf:3.4.5'
     implementation 'org.springframework.boot:spring-boot-starter-validation:3.4.5'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
+    testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
+    testImplementation 'com.h2database:h2:2.3.232'
 
     // JUnit 5 (JUnit Jupiter) を明示的に追加
     testImplementation 'org.junit.jupiter:junit-jupiter-api'

--- a/src/main/java/raisetechtask/taskstudentsmanagement/finalversion/data/ApplicationStatus.java
+++ b/src/main/java/raisetechtask/taskstudentsmanagement/finalversion/data/ApplicationStatus.java
@@ -1,0 +1,21 @@
+package raisetechtask.taskstudentsmanagement.finalversion.data;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+@Builder
+public class ApplicationStatus {
+
+	private int id;
+	private int studentCourseId;
+	private ApplicationStatusEnum status;
+}

--- a/src/main/java/raisetechtask/taskstudentsmanagement/finalversion/data/ApplicationStatusEnum.java
+++ b/src/main/java/raisetechtask/taskstudentsmanagement/finalversion/data/ApplicationStatusEnum.java
@@ -17,7 +17,18 @@ public enum ApplicationStatusEnum {
 		this.displayValue = displayValue;
 	}
 
+	//定数から表示値を取得する操作
 	public String getDisplayValue() {
 		return displayValue;
+	}
+
+	//リクエストされた情報を定数に変換する操作
+	public static ApplicationStatusEnum fromDisplayValue(String displayValue) {
+		for ( ApplicationStatusEnum statusEnum : ApplicationStatusEnum.values() ) {
+			if ( statusEnum.displayValue.equals(displayValue) ) {
+				return statusEnum;
+			}
+		}
+		throw new IllegalArgumentException("存在しない定数です。" + displayValue);
 	}
 }

--- a/src/main/java/raisetechtask/taskstudentsmanagement/finalversion/data/ApplicationStatusEnum.java
+++ b/src/main/java/raisetechtask/taskstudentsmanagement/finalversion/data/ApplicationStatusEnum.java
@@ -1,0 +1,23 @@
+package raisetechtask.taskstudentsmanagement.finalversion.data;
+
+public enum ApplicationStatusEnum {
+
+	/* enumの場合,自動的に定数(=public static final)として扱われる
+	命名規則はすべて大文字+スネークケース
+	フィールドでの宣言
+	*/
+	KARI_MOSIKOMI("仮申込"),
+	HON_MOSIKOMI("本申込"),
+	JUKOCHU("受講中"),
+	JUKO_SHURYO("受講終了");
+
+	private final String displayValue;
+
+	ApplicationStatusEnum(String displayValue) {
+		this.displayValue = displayValue;
+	}
+
+	public String getDisplayValue() {
+		return displayValue;
+	}
+}

--- a/src/main/java/raisetechtask/taskstudentsmanagement/finalversion/data/ApplicationStatusEnum.java
+++ b/src/main/java/raisetechtask/taskstudentsmanagement/finalversion/data/ApplicationStatusEnum.java
@@ -1,5 +1,6 @@
 package raisetechtask.taskstudentsmanagement.finalversion.data;
 
+
 public enum ApplicationStatusEnum {
 
 	/* enumの場合,自動的に定数(=public static final)として扱われる

--- a/src/main/java/raisetechtask/taskstudentsmanagement/finalversion/data/Course.java
+++ b/src/main/java/raisetechtask/taskstudentsmanagement/finalversion/data/Course.java
@@ -3,6 +3,7 @@ package raisetechtask.taskstudentsmanagement.finalversion.data;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,6 +17,7 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode
+@Builder
 public class Course {
 	@PositiveOrZero
 	private int id;

--- a/src/main/java/raisetechtask/taskstudentsmanagement/finalversion/data/Student.java
+++ b/src/main/java/raisetechtask/taskstudentsmanagement/finalversion/data/Student.java
@@ -27,6 +27,6 @@ public class Student {
 	private int age;
 	private String gender;
 	private String remark;
-	private boolean deleted;
+	private boolean isDeleted;
 
 }

--- a/src/main/java/raisetechtask/taskstudentsmanagement/finalversion/data/Student.java
+++ b/src/main/java/raisetechtask/taskstudentsmanagement/finalversion/data/Student.java
@@ -3,6 +3,7 @@ package raisetechtask.taskstudentsmanagement.finalversion.data;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,6 +15,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode
+@Builder
 public class Student {
 	@PositiveOrZero
 	private int id;
@@ -26,4 +28,5 @@ public class Student {
 	private String gender;
 	private String remark;
 	private boolean deleted;
+
 }

--- a/src/main/java/raisetechtask/taskstudentsmanagement/finalversion/repository/ApplicationStatusRepository.java
+++ b/src/main/java/raisetechtask/taskstudentsmanagement/finalversion/repository/ApplicationStatusRepository.java
@@ -1,12 +1,14 @@
 package raisetechtask.taskstudentsmanagement.finalversion.repository;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import raisetechtask.taskstudentsmanagement.finalversion.data.ApplicationStatus;
 import raisetechtask.taskstudentsmanagement.finalversion.data.ApplicationStatusEnum;
 
 import java.util.List;
 
 @Mapper
+
 public interface ApplicationStatusRepository {
 
 	//申し込み状況の全件検索
@@ -19,6 +21,6 @@ public interface ApplicationStatusRepository {
 	int registerStatus(ApplicationStatus applicationStatus);
 
 	//申し込み状況の更新処理_戻り値をintにすることで整数で成功・失敗の判断を行う
-	int updateStatus(ApplicationStatusEnum applicationStatusEnum);
+	int updateStatus(@Param("studentCourseId") int studentCourseId, @Param("status") ApplicationStatusEnum Enumstatus);
 
 }

--- a/src/main/java/raisetechtask/taskstudentsmanagement/finalversion/repository/ApplicationStatusRepository.java
+++ b/src/main/java/raisetechtask/taskstudentsmanagement/finalversion/repository/ApplicationStatusRepository.java
@@ -2,6 +2,7 @@ package raisetechtask.taskstudentsmanagement.finalversion.repository;
 
 import org.apache.ibatis.annotations.Mapper;
 import raisetechtask.taskstudentsmanagement.finalversion.data.ApplicationStatus;
+import raisetechtask.taskstudentsmanagement.finalversion.data.ApplicationStatusEnum;
 
 import java.util.List;
 
@@ -14,10 +15,10 @@ public interface ApplicationStatusRepository {
 	//コースIDに紐づいた申し込み状況の検索
 	ApplicationStatus searchStudentCourseStatus(int studentCourseId);
 
-	//申し込み状況の登録処理_戻り値をintにすることで0or1で成功・失敗の判断を行う
+	//申し込み状況の登録処理_戻り値をintにすることで整数で成功・失敗の判断を行う
 	int registerStatus(ApplicationStatus applicationStatus);
 
-	//申し込み状況の更新処理_戻り値をintにすることで0or1で成功・失敗の判断を行う
-	int updateStatus(ApplicationStatus applicationStatus);
+	//申し込み状況の更新処理_戻り値をintにすることで整数で成功・失敗の判断を行う
+	int updateStatus(ApplicationStatusEnum applicationStatusEnum);
 
 }

--- a/src/main/java/raisetechtask/taskstudentsmanagement/finalversion/repository/ApplicationStatusRepository.java
+++ b/src/main/java/raisetechtask/taskstudentsmanagement/finalversion/repository/ApplicationStatusRepository.java
@@ -1,9 +1,23 @@
 package raisetechtask.taskstudentsmanagement.finalversion.repository;
 
 import org.apache.ibatis.annotations.Mapper;
+import raisetechtask.taskstudentsmanagement.finalversion.data.ApplicationStatus;
+
+import java.util.List;
 
 @Mapper
 public interface ApplicationStatusRepository {
 
+	//申し込み状況の全件検索
+	List<ApplicationStatus> searchStudentCourseStatusList();
+
+	//コースIDに紐づいた申し込み状況の検索
+	ApplicationStatus searchStudentCourseStatus(int studentCourseId);
+
+	//申し込み状況の登録処理_戻り値をintにすることで0or1で成功・失敗の判断を行う
+	int registerStatus(ApplicationStatus applicationStatus);
+
+	//申し込み状況の更新処理_戻り値をintにすることで0or1で成功・失敗の判断を行う
+	int updateStatus(ApplicationStatus applicationStatus);
 
 }

--- a/src/main/java/raisetechtask/taskstudentsmanagement/finalversion/repository/ApplicationStatusRepository.java
+++ b/src/main/java/raisetechtask/taskstudentsmanagement/finalversion/repository/ApplicationStatusRepository.java
@@ -1,0 +1,9 @@
+package raisetechtask.taskstudentsmanagement.finalversion.repository;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface ApplicationStatusRepository {
+
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,9 @@
 spring.application.name=TaskStudentsManagement
-# MySQL???
+# MySQL
 spring.datasource.url=jdbc:mysql://localhost:3306/task_student_management
 spring.datasource.username=root
 spring.datasource.password=Karakuri1125
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-# MyBatis???
+# MyBatis
 mybatis.configuration.map-underscore-to-camel-case=true
 mybatis.mapper-locations=classpath*:/mapper/*.xml

--- a/src/main/resources/mapper/ApplicationStatusRepository.xml
+++ b/src/main/resources/mapper/ApplicationStatusRepository.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="raisetechtask.taskstudentsmanagement.finalversion.repository.ApplicationStatusRepository">
+
+
+</mapper>

--- a/src/main/resources/mapper/ApplicationStatusRepository.xml
+++ b/src/main/resources/mapper/ApplicationStatusRepository.xml
@@ -28,7 +28,7 @@
     </insert>
 
     <!--申し込み状況の更新 -->
-    <update id="updateStatus" parameterType="ApplicationStatus">
+    <update id="updateStatus">
         UPDATE application_status SET status = #{status}
         WHERE student_course_id = #{studentCourseId}
     </update>

--- a/src/main/resources/mapper/ApplicationStatusRepository.xml
+++ b/src/main/resources/mapper/ApplicationStatusRepository.xml
@@ -24,12 +24,12 @@
         INSERT INTO application_status (
         student_course_id, status)
         VALUES(
-        #{studentCourseId}, #{status})
+        #{studentCourseId}, #{status, jdbcType=VARCHAR})
     </insert>
 
     <!--申し込み状況の更新 -->
-    <update id="updateStatus" parameterType="ApplicationStatus">
-        UPDATE application_status SET status = #{status}
+    <update id="updateStatus" parameterType="ApplicationStatusEnum">
+        UPDATE application_status SET status = #{status.displayValue, jdbcType=VARCHAR}
         WHERE id = #{id}
     </update>
 </mapper>

--- a/src/main/resources/mapper/ApplicationStatusRepository.xml
+++ b/src/main/resources/mapper/ApplicationStatusRepository.xml
@@ -4,5 +4,32 @@
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="raisetechtask.taskstudentsmanagement.finalversion.repository.ApplicationStatusRepository">
 
+    <!--申し込み状況の全件検索 -->
+    <select id="searchStudentCourseStatusList"
+            resultType="raisetechtask.taskstudentsmanagement.finalversion.data.ApplicationStatus">
+        SELECT *
+        FROM application_status
+    </select>
 
+    <!--コースIDに紐づいた申し込み状況の検索 -->
+    <select id="searchStudentCourseStatus"
+            resultType="raisetechtask.taskstudentsmanagement.finalversion.data.ApplicationStatus">
+        SELECT *
+        FROM application_status
+        WHERE student_course_id = #{studentCourseId}
+    </select>
+
+    <!--申し込み状況の登録 -->
+    <insert id="registerStatus" parameterType="ApplicationStatus" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO application_status (
+        student_course_id, status)
+        VALUES(
+        #{studentCourseId}, #{status})
+    </insert>
+
+    <!--申し込み状況の更新 -->
+    <update id="updateStatus" parameterType="ApplicationStatus">
+        UPDATE application_status SET status = #{status}
+        WHERE id = #{id}
+    </update>
 </mapper>

--- a/src/main/resources/mapper/ApplicationStatusRepository.xml
+++ b/src/main/resources/mapper/ApplicationStatusRepository.xml
@@ -28,8 +28,8 @@
     </insert>
 
     <!--申し込み状況の更新 -->
-    <update id="updateStatus" parameterType="ApplicationStatusEnum">
-        UPDATE application_status SET status = #{status.displayValue, jdbcType=VARCHAR}
-        WHERE id = #{id}
+    <update id="updateStatus" parameterType="ApplicationStatus">
+        UPDATE application_status SET status = #{status}
+        WHERE student_course_id = #{studentCourseId}
     </update>
 </mapper>

--- a/src/main/resources/mapper/CoursesRepository.xml
+++ b/src/main/resources/mapper/CoursesRepository.xml
@@ -2,22 +2,22 @@
 <!DOCTYPE mapper
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="repository.raisetechtask.taskstudentsmanagement.finalversion.CoursesRepository">
+<mapper namespace="raisetechtask.taskstudentsmanagement.finalversion.repository.CoursesRepository">
     <!-- コース情報の全件検索-->
-    <select id="searchCourses" resultType="data.raisetechtask.taskstudentsmanagement.finalversion.Course">
+    <select id="searchCourses" resultType="Course">
         SELECT *
         FROM students_courses
     </select>
 
     <!-- 受講生IDに紐づいてたコース情報の検索-->
-    <select id="searchStudentCourse" resultType="data.raisetechtask.taskstudentsmanagement.finalversion.Course">
+    <select id="searchStudentCourse" resultType="Course">
         SELECT *
         FROM students_courses
         WHERE student_id = #{studentId}
     </select>
 
     <!--受講生IDに紐づいたコース情報の登録 -->
-    <insert id="registerStudentCourses" parameterType="data.raisetechtask.taskstudentsmanagement.finalversion.Course"
+    <insert id="registerStudentCourses" parameterType="Course"
             useGeneratedKeys="true" keyProperty="id">
         INSERT INTO students_courses (
         student_id, course_name, course_start_day, course_completion_day)
@@ -26,7 +26,7 @@
     </insert>
 
     <!--受講生IDに紐づいたコース情報の更新 -->
-    <update id="updateStudentCourses" parameterType="data.raisetechtask.taskstudentsmanagement.finalversion.Course">
+    <update id="updateStudentCourses" parameterType="Course">
         UPDATE students_courses SET course_name = #{courseName}
         WHERE id = #{id}
     </update>

--- a/src/main/resources/mapper/StudentRepository.xml
+++ b/src/main/resources/mapper/StudentRepository.xml
@@ -2,22 +2,22 @@
 <!DOCTYPE mapper
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="repository.raisetechtask.taskstudentsmanagement.finalversion.StudentsRepository">
+<mapper namespace="raisetechtask.taskstudentsmanagement.finalversion.repository.StudentsRepository">
     <!-- 受講生の全件検索-->
-    <select id="searchStudentsList" resultType="data.raisetechtask.taskstudentsmanagement.finalversion.Student">
+    <select id="searchStudentsList" resultType="Student">
         SELECT *
         FROM students
     </select>
 
     <!-- 受講生の検索-->
-    <select id="searchStudent" resultType="data.raisetechtask.taskstudentsmanagement.finalversion.Student">
+    <select id="searchStudent" resultType="Student">
         SELECT *
         FROM students
         WHERE id = #{id}
     </select>
 
     <!--受講生の登録 -->
-    <insert id="registerStudent" parameterType="data.raisetechtask.taskstudentsmanagement.finalversion.Student"
+    <insert id="registerStudent" parameterType="Student"
             useGeneratedKeys="true" keyProperty="id">
         INSERT INTO students(
         full_name, furigana, nickname, email_address, address, age, gender, remark, is_Deleted)
@@ -26,7 +26,7 @@
     </insert>
 
     <!--受講生の更新 -->
-    <update id="updateStudent" parameterType="data.raisetechtask.taskstudentsmanagement.finalversion.Student">
+    <update id="updateStudent" parameterType="Student">
         UPDATE students
         SET
         full_name = #{fullName},

--- a/src/main/resources/mapper/StudentRepository.xml
+++ b/src/main/resources/mapper/StudentRepository.xml
@@ -22,7 +22,7 @@
         INSERT INTO students(
         full_name, furigana, nickname, email_address, address, age, gender, remark, is_Deleted)
         VALUES(
-        #{fullName}, #{furigana}, #{nickname}, #{emailAddress}, #{address}, #{age}, #{gender}, #{remark}, #{deleted})
+        #{fullName}, #{furigana}, #{nickname}, #{emailAddress}, #{address}, #{age}, #{gender}, #{remark}, #{isDeleted})
     </insert>
 
     <!--受講生の更新 -->
@@ -37,7 +37,7 @@
         age = #{age},
         gender =#{gender},
         remark =#{remark},
-        is_deleted = #{deleted}
+        is_deleted = #{isDeleted}
         WHERE id = #{id}
     </update>
 </mapper>

--- a/src/test/java/raisetechtask/taskstudentsmanagement/finalversion/converter/StudentConverterTest.java
+++ b/src/test/java/raisetechtask/taskstudentsmanagement/finalversion/converter/StudentConverterTest.java
@@ -53,7 +53,7 @@ class StudentConverterTest {
 	}
 
 	@Test
-	void 複数の受講生情報と受講生IDに紐づいた空のコース情報が返ってきていること() {
+	void 複数の受講生情報と受講生に紐づいた空のコース情報が返ってきていること() {
 		Student student = new Student(999, "田中太郎", "タナカタロウ", "たなか", "rftgyhu@huji.com", "東京", 35, "男性", "", false);
 		Student student1 = new Student(888, "田中ジロウ", "タナカジロウ", "じろう", "rgyu@huji.com", "沖縄", 40, "男性", "", false);
 		List<Student> studentList = new ArrayList<>();

--- a/src/test/java/raisetechtask/taskstudentsmanagement/finalversion/converter/StudentConverterTest.java
+++ b/src/test/java/raisetechtask/taskstudentsmanagement/finalversion/converter/StudentConverterTest.java
@@ -6,9 +6,11 @@ import raisetechtask.taskstudentsmanagement.finalversion.data.Course;
 import raisetechtask.taskstudentsmanagement.finalversion.data.Student;
 import raisetechtask.taskstudentsmanagement.finalversion.domain.StudentDetail;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -76,5 +78,19 @@ class StudentConverterTest {
 		List<StudentDetail> actualStudentDetails = converter.convertStudentDetails(studentList, courseList);
 		//検証
 		assertEquals(expectedStudentDetails, actualStudentDetails);
+	}
+
+	@Test
+	void 受講生のリストと受講生コース情報のリストを渡したときに紐づかない受講生コース情報は除外されること() {
+		Student student = new Student(999, "田中太郎", "タナカタロウ", "たなか", "rftgyhu@huji.com", "東京", 35, "男性", "", false);
+		Course course = new Course(999, 888, "Java", LocalDate.now(), LocalDate.now().plusYears(1));
+
+		List<Student> studentList = List.of(student);
+		List<Course> courseList = List.of(course);
+
+		List<StudentDetail> actual = converter.convertStudentDetails(studentList, courseList);
+
+		assertThat(actual.get(0).getStudent()).isEqualTo(student);
+		assertThat(actual.get(0).getStudentCourseList()).isEmpty();
 	}
 }

--- a/src/test/java/raisetechtask/taskstudentsmanagement/finalversion/data/ApplicationStatusEnumTest.java
+++ b/src/test/java/raisetechtask/taskstudentsmanagement/finalversion/data/ApplicationStatusEnumTest.java
@@ -1,0 +1,63 @@
+package raisetechtask.taskstudentsmanagement.finalversion.data;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@MybatisTest
+class ApplicationStatusEnumTest {
+
+	@ParameterizedTest
+	@MethodSource("provideEnumAndDisplayValue")
+	void 定数で宣言されている申込状況が適切な表示値となっていること(
+			ApplicationStatusEnum statusEnum, String expectedDisplayValue) {
+		assertThat(statusEnum.getDisplayValue()).isEqualTo(expectedDisplayValue);
+	}
+
+	@ParameterizedTest
+	@MethodSource("provideDisplayValueAndEnum")
+	void 受け取った表示名がEnum定数に適切に変換されること(String displayValue, ApplicationStatusEnum expectedEnum) {
+		assertThat(ApplicationStatusEnum.fromDisplayValue(displayValue)).isEqualTo(expectedEnum);
+	}
+
+	@ParameterizedTest
+	@MethodSource("provideInvalidDisplayValues")
+	void 特定の例外がスローされること(String invalidDisplayValue) {
+		assertThatThrownBy(() -> ApplicationStatusEnum.fromDisplayValue(invalidDisplayValue))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("存在しない定数です。");
+	}
+
+
+	static Stream<Arguments> provideEnumAndDisplayValue() {
+		return Stream.of(
+				Arguments.of(ApplicationStatusEnum.KARI_MOSIKOMI, "仮申込"),
+				Arguments.of(ApplicationStatusEnum.HON_MOSIKOMI, "本申込"),
+				Arguments.of(ApplicationStatusEnum.JUKOCHU, "受講中"),
+				Arguments.of(ApplicationStatusEnum.JUKO_SHURYO, "受講終了")
+		);
+	}
+
+	static Stream<Arguments> provideDisplayValueAndEnum() {
+		return Stream.of(
+				Arguments.of("仮申込", ApplicationStatusEnum.KARI_MOSIKOMI),
+				Arguments.of("本申込", ApplicationStatusEnum.HON_MOSIKOMI),
+				Arguments.of("受講中", ApplicationStatusEnum.JUKOCHU),
+				Arguments.of("受講終了", ApplicationStatusEnum.JUKO_SHURYO)
+		);
+	}
+
+	static Stream<Arguments> provideInvalidDisplayValues() {
+		return Stream.of(
+				Arguments.of("存在しない値"),
+				Arguments.of("invalid_status"),
+				Arguments.of("")
+		);
+	}
+}

--- a/src/test/java/raisetechtask/taskstudentsmanagement/finalversion/demoDate.java
+++ b/src/test/java/raisetechtask/taskstudentsmanagement/finalversion/demoDate.java
@@ -1,0 +1,47 @@
+package raisetechtask.taskstudentsmanagement.finalversion;
+
+import org.springframework.stereotype.Component;
+import raisetechtask.taskstudentsmanagement.finalversion.data.ApplicationStatus;
+import raisetechtask.taskstudentsmanagement.finalversion.data.ApplicationStatusEnum;
+import raisetechtask.taskstudentsmanagement.finalversion.data.Course;
+import raisetechtask.taskstudentsmanagement.finalversion.data.Student;
+
+import java.time.LocalDate;
+
+@Component
+public class demoDate {
+
+
+	// ダミーデータ_申込状況_登録更新前
+	public ApplicationStatus createDefaultStatus() {
+		return ApplicationStatus.builder()
+				.studentCourseId(0)
+				.status(ApplicationStatusEnum.HON_MOSIKOMI)
+				.build();
+	}
+
+	// ダミーデータ_受講生情報
+	public Student createDefaultStudent() {
+		return Student.builder()
+				.fullName("デフォルト太郎")
+				.furigana("デフォルトタロウ")
+				.nickname("デモニック")
+				.emailAddress("default.test@example.com")
+				.address("東京都千代田区")
+				.age(25)
+				.gender("男性")
+				.remark("デフォルトデータ")
+				.isDeleted(false)
+				.build();
+	}
+
+	// ダミーデータ_コース情報
+	public Course createDefaultCourse() {
+		return Course.builder()
+				.studentId(0)
+				.courseName("テストコース")
+				.courseStartDay(LocalDate.now())
+				.courseCompletionDay(LocalDate.now().plusMonths(3))
+				.build();
+	}
+}

--- a/src/test/java/raisetechtask/taskstudentsmanagement/finalversion/repository/ApplicationStatusRepositoryTest.java
+++ b/src/test/java/raisetechtask/taskstudentsmanagement/finalversion/repository/ApplicationStatusRepositoryTest.java
@@ -1,0 +1,131 @@
+package raisetechtask.taskstudentsmanagement.finalversion.repository;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import raisetechtask.taskstudentsmanagement.finalversion.data.ApplicationStatus;
+import raisetechtask.taskstudentsmanagement.finalversion.data.ApplicationStatusEnum;
+import raisetechtask.taskstudentsmanagement.finalversion.data.Course;
+import raisetechtask.taskstudentsmanagement.finalversion.data.Student;
+import raisetechtask.taskstudentsmanagement.finalversion.demoDate;
+
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.doNothing;
+import static raisetechtask.taskstudentsmanagement.finalversion.data.ApplicationStatusEnum.fromDisplayValue;
+
+@MybatisTest
+@ExtendWith(MockitoExtension.class)
+@ComponentScan(basePackages = "raisetechtask.taskstudentsmanagement.finalversion")
+class ApplicationStatusRepositoryTest {
+
+
+	@Autowired //実際にDBアクセスするので @Autowired
+	private ApplicationStatusRepository statusSut;
+
+	@Autowired
+	public demoDate demoDate;
+
+	@Mock
+	private StudentsRepository studentSut;
+
+	@Mock
+	private CoursesRepository courseSut;
+
+
+	@Test
+	void 申し込み状況の全件検索が行えること() {
+		List<ApplicationStatus> actual = statusSut.searchStudentCourseStatusList();
+		assertThat(actual.size()).isEqualTo(5);
+	}
+
+	@Test
+	void コースIDに紐づいた申し込み状況の検索_正常系() {
+		int testCourseId = 101; // 実際に存在するIDを使用
+		ApplicationStatusEnum expectedStatus = ApplicationStatusEnum.KARI_MOSIKOMI;
+		// Act:
+		ApplicationStatus actual = statusSut.searchStudentCourseStatus(testCourseId);
+		// Assert:
+		assertThat(actual).isNotNull();
+		assertThat(actual.getStudentCourseId()).isEqualTo(testCourseId);
+		assertThat(actual.getStatus()).isEqualTo(expectedStatus);
+	}
+
+	@Test
+	void 存在しないコースIDで検索された場合Nullを返すこと() {
+		int testCourseId = 987654321; // 確実に存在しないID
+		// Act:
+		ApplicationStatus actual = statusSut.searchStudentCourseStatus(testCourseId);
+		// Assert:
+		assertThat(actual).isNull();
+	}
+
+	@Test
+	void 受講生IDとコースIDに紐づいた申込状況を登録することができること() {
+		int testCourseId = 74;
+		registedDemoStudent();//受講生の登録操作のみスルー　実体はなし
+		registedDemoCourse();//受講生コースの登録操作のみスルー　実体はなし
+		ApplicationStatus demoStatus = demoDate.createDefaultStatus();//ダミーの申込状況情報
+		demoStatus.setStudentCourseId(testCourseId);//紐づいたコースIDを設定
+		demoStatus.setStatus(ApplicationStatusEnum.HON_MOSIKOMI);//登録する申込状況の設定
+		// Act
+		int registedStatus = statusSut.registerStatus(demoStatus); // 申込状況のみＨ２に登録
+		ApplicationStatus actual = statusSut.searchStudentCourseStatus(testCourseId);//登録後に検索して検証へ
+		// Assert:
+		assertThat(registedStatus).isEqualTo(1); // 登録成功件数
+		assertThat(actual).isNotNull();
+		assertThat(actual.getStudentCourseId()).isEqualTo(testCourseId);//作ったIDと登録後のIDが一致しているか
+		assertThat(actual.getStatus()).isEqualTo(ApplicationStatusEnum.HON_MOSIKOMI);//登録したダミーの申込状況がEnumにある定数と一致するか
+	}
+
+
+	@Test
+	void updateStatus_登録済み申し込み状況が更新できること() {
+		ApplicationStatus demoStatus = getApplicationStatus();
+		int registedStatus = statusSut.registerStatus(demoStatus);
+		String updateStatus = ("受講中");
+		ApplicationStatusEnum updateDemoStatus = fromDisplayValue(updateStatus);
+
+		int update = statusSut.updateStatus(updateDemoStatus);
+		ApplicationStatus actual = statusSut.searchStudentCourseStatus(demoStatus.getStudentCourseId());
+
+		assertThat(update).isEqualTo(1);
+		assertThat(actual.getStatus()).isEqualTo(updateStatus);
+		assertThat(actual).isNotNull();
+	}
+
+	//ダミーの申込情報の登録処理
+	private ApplicationStatus getApplicationStatus() {
+		int testCourseId = 256;
+		registedDemoStudent();
+		registedDemoCourse();
+		ApplicationStatus demoStatus = demoDate.createDefaultStatus();
+		demoStatus.setStudentCourseId(testCourseId);
+		demoStatus.setStatus(ApplicationStatusEnum.HON_MOSIKOMI);
+		return demoStatus;
+	}
+
+	//ダミーの受講生情報の登録処理（Mock）
+	private void registedDemoStudent() {
+		Student demoStudent = demoDate.createDefaultStudent();
+		demoStudent.setId(741);
+
+		doNothing().when(studentSut).registerStudent(demoStudent);
+		studentSut.registerStudent(demoStudent);
+	}
+
+	//ダミーのコース情報の登録処理（Mock）
+	private void registedDemoCourse() {
+		Course demoCourse = demoDate.createDefaultCourse();
+		demoCourse.setId(74);
+
+		doNothing().when(courseSut).registerStudentCourses(demoCourse);
+		courseSut.registerStudentCourses(demoCourse);
+	}
+
+}

--- a/src/test/java/raisetechtask/taskstudentsmanagement/finalversion/repository/ApplicationStatusRepositoryTest.java
+++ b/src/test/java/raisetechtask/taskstudentsmanagement/finalversion/repository/ApplicationStatusRepositoryTest.java
@@ -86,18 +86,19 @@ class ApplicationStatusRepositoryTest {
 
 	@Test
 	void updateStatus_登録済み申し込み状況が更新できること() {
-		ApplicationStatus demoStatus = getApplicationStatus();
-		int registedStatus = statusSut.registerStatus(demoStatus);
-		String updateStatus = ("受講中");
-		ApplicationStatusEnum updateDemoStatus = fromDisplayValue(updateStatus);
+		ApplicationStatus demoStatus = getApplicationStatus();//ダミーデータメソッド
+		int registedStatus = statusSut.registerStatus(demoStatus);//ダミーの登録処理
+		String updateStatus = ("受講中");//更新内容（本申込→受講中）
+		ApplicationStatusEnum updateDemoStatus = fromDisplayValue(updateStatus);//Enumクラスにある変換メソッドへ
 
-		int update = statusSut.updateStatus(updateDemoStatus);
-		ApplicationStatus actual = statusSut.searchStudentCourseStatus(demoStatus.getStudentCourseId());
+		int update = statusSut.updateStatus(demoStatus.getStudentCourseId(), updateDemoStatus);//更新メソッド（コースIDとEnum(name)
+		ApplicationStatus actual = statusSut.searchStudentCourseStatus(demoStatus.getStudentCourseId());//更新後呼び出し
 
-		assertThat(update).isEqualTo(1);
-		assertThat(actual.getStatus()).isEqualTo(updateStatus);
+		assertThat(update).isEqualTo(1);//呼び出し回数
+		assertThat(actual.getStatus()).isEqualTo(updateDemoStatus);//JUKOCHU＝JUKOCHUか
 		assertThat(actual).isNotNull();
 	}
+
 
 	//ダミーの申込情報の登録処理
 	private ApplicationStatus getApplicationStatus() {

--- a/src/test/java/raisetechtask/taskstudentsmanagement/finalversion/repository/CoursesRepositoryTest.java
+++ b/src/test/java/raisetechtask/taskstudentsmanagement/finalversion/repository/CoursesRepositoryTest.java
@@ -1,0 +1,14 @@
+package raisetechtask.taskstudentsmanagement.finalversion.repository;
+
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+
+@MybatisTest
+class CoursesRepositoryTest {
+
+	@Test
+	void test() {
+
+	}
+
+}

--- a/src/test/java/raisetechtask/taskstudentsmanagement/finalversion/repository/CoursesRepositoryTest.java
+++ b/src/test/java/raisetechtask/taskstudentsmanagement/finalversion/repository/CoursesRepositoryTest.java
@@ -2,13 +2,104 @@ package raisetechtask.taskstudentsmanagement.finalversion.repository;
 
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import raisetechtask.taskstudentsmanagement.finalversion.data.Course;
+import raisetechtask.taskstudentsmanagement.finalversion.data.Student;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @MybatisTest
 class CoursesRepositoryTest {
 
-	@Test
-	void test() {
+	@Autowired
+	private CoursesRepository sut;
+	@Autowired
+	private StudentsRepository studentSut;
 
+	@Test
+	void コース情報の全件検索が行えること() {
+		List<Course> actual = sut.searchCourses();
+		assertThat(actual.size()).isEqualTo(5);
+	}
+
+	@Test
+	void 受講生IDに紐づいたコース情報の検索が行えること() {
+		Student studentToRegister = createDefaultStudent();
+		studentToRegister.setId(999);
+		studentSut.registerStudent(studentToRegister);
+
+		Course courseToRegister = createDefaultCourse();
+		sut.registerStudentCourses(courseToRegister);
+
+
+		List<Course> actualCourses = sut.searchStudentCourse(courseToRegister.getStudentId());
+
+		Course foundCourse = actualCourses.getFirst();
+		assertThat(actualCourses).isNotNull();
+	}
+
+
+	@Test
+	void コース情報の登録が行えること() {
+		Student studentForCourse = createDefaultStudent();
+		studentForCourse.setId(999);
+		studentSut.registerStudent(studentForCourse);
+
+		Course courseToRegister = createDefaultCourse();
+		sut.registerStudentCourses(courseToRegister);
+
+		List<Course> allCourses = sut.searchCourses();
+		assertThat(allCourses.size()).isEqualTo(6);
+	}
+
+	@Test
+	void コース名の更新が行えること() {
+		Student studentForUpdate = createDefaultStudent();
+		studentForUpdate.setId(999);
+		studentSut.registerStudent(studentForUpdate);
+
+		Course initialCourse = createDefaultCourse();
+		sut.registerStudentCourses(initialCourse);
+
+		List<Course> coursesFromDb = sut.searchStudentCourse(initialCourse.getStudentId());
+		assertThat(coursesFromDb).hasSize(1);
+		Course courseToUpdate = coursesFromDb.getFirst();
+
+		String updatedCourseName = "更新後のテストコース名";
+		courseToUpdate.setCourseName(updatedCourseName);
+
+		sut.updateStudentCourses(courseToUpdate);
+
+		List<Course> updatedCoursesFromDb = sut.searchStudentCourse(initialCourse.getStudentId());
+		assertThat(updatedCoursesFromDb).hasSize(1);
+	}
+
+	//ヘルパーメソッド
+	private Course createDefaultCourse() {
+		return Course.builder()
+				.id(999)
+				.studentId(999)
+				.courseName("テストコース")
+				.courseStartDay(LocalDate.now())
+				.courseCompletionDay(LocalDate.now().plusMonths(3))
+				.build();
+	}
+
+	private Student createDefaultStudent() {
+		return Student.builder()
+				.fullName("デフォルト太郎")
+				.furigana("デフォルトタロウ")
+				.nickname("デモニック")
+				.emailAddress("default.test@example.com")
+				.address("東京都千代田区")
+				.age(25)
+				.gender("男性")
+				.remark("デフォルトデータ")
+				.isDeleted(false)
+				.build();
 	}
 
 }

--- a/src/test/java/raisetechtask/taskstudentsmanagement/finalversion/repository/StudentsRepositoryTest.java
+++ b/src/test/java/raisetechtask/taskstudentsmanagement/finalversion/repository/StudentsRepositoryTest.java
@@ -23,11 +23,12 @@ class StudentsRepositoryTest {
 
 	@Test
 	void IDに紐づいた受講生情報の検索が行えること() {
-		sut.registerStudent(createDefaultStudent());
+		Student studentToRegister = createDefaultStudent();
+		sut.registerStudent(studentToRegister);
 
-		Student actual = sut.searchStudent(createDefaultStudent().getId());
+		Student actual = sut.searchStudent(studentToRegister.getId());
 
-		assertThat(actual.getId()).isEqualTo(createDefaultStudent().getId());
+		assertThat(actual.getId()).isEqualTo(studentToRegister.getId());
 	}
 
 

--- a/src/test/java/raisetechtask/taskstudentsmanagement/finalversion/repository/StudentsRepositoryTest.java
+++ b/src/test/java/raisetechtask/taskstudentsmanagement/finalversion/repository/StudentsRepositoryTest.java
@@ -1,0 +1,45 @@
+package raisetechtask.taskstudentsmanagement.finalversion.repository;
+
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import raisetechtask.taskstudentsmanagement.finalversion.data.Student;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MybatisTest//テスト終了時自動でロールバックする
+class StudentsRepositoryTest {
+
+	@Autowired
+	private StudentsRepository sut;
+
+	@Test
+	void 受講生の全件検索が行えること() {
+		List<Student> actual = sut.searchStudentsList();
+		assertThat(actual.size()).isEqualTo(5);
+	}
+
+
+	@Test
+	void 図構成の登録が行えること() {
+		Student student = Student.builder()
+				.fullName("田中太郎")
+				.furigana("タナカタロウ")
+				.nickname("たなか")
+				.emailAddress("rftgyhu@huji.com")
+				.address("東京")
+				.age(35)
+				.gender("男性")
+				.remark("")
+				.deleted(false)
+				.build();
+
+		sut.registerStudent(student);
+
+		List<Student> actual = sut.searchStudentsList();
+		assertThat(actual.size()).isEqualTo(5);
+
+	}
+}

--- a/src/test/java/raisetechtask/taskstudentsmanagement/finalversion/repository/StudentsRepositoryTest.java
+++ b/src/test/java/raisetechtask/taskstudentsmanagement/finalversion/repository/StudentsRepositoryTest.java
@@ -3,11 +3,14 @@ package raisetechtask.taskstudentsmanagement.finalversion.repository;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import raisetechtask.taskstudentsmanagement.finalversion.data.Student;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @MybatisTest//テスト終了時自動でロールバックする
 class StudentsRepositoryTest {
@@ -31,6 +34,14 @@ class StudentsRepositoryTest {
 		assertThat(actual.getId()).isEqualTo(studentToRegister.getId());
 	}
 
+	@Test
+	void IDに紐づいた受講生の情報が見つからない場合() {
+		int nonExistentStudentId = 9999999; // 確実に存在しないID
+		Student actual = sut.searchStudent(nonExistentStudentId);
+
+		assertNull(actual, "存在しないIDで検索した場合、nullが返るべきです");
+	}
+
 
 	@Test
 	void 受講生の登録が行えること() {
@@ -38,6 +49,16 @@ class StudentsRepositoryTest {
 
 		List<Student> actual = sut.searchStudentsList();
 		assertThat(actual.size()).isEqualTo(6);
+	}
+
+	@Test
+	void 必須項目がnullの場合に登録処理が実行できないこと() {
+		Student studentWithNullName = Student.builder()
+				.fullName(null)
+				.build();
+
+		assertThrows(DataIntegrityViolationException.class, () -> sut.registerStudent(studentWithNullName),
+				"必須項目がnull");
 	}
 
 	@Test

--- a/src/test/java/raisetechtask/taskstudentsmanagement/finalversion/repository/StudentsRepositoryTest.java
+++ b/src/test/java/raisetechtask/taskstudentsmanagement/finalversion/repository/StudentsRepositoryTest.java
@@ -21,25 +21,51 @@ class StudentsRepositoryTest {
 		assertThat(actual.size()).isEqualTo(5);
 	}
 
+	@Test
+	void IDに紐づいた受講生情報の検索が行えること() {
+		sut.registerStudent(createDefaultStudent());
+
+		Student actual = sut.searchStudent(createDefaultStudent().getId());
+
+		assertThat(actual.getId()).isEqualTo(createDefaultStudent().getId());
+	}
+
 
 	@Test
-	void 図構成の登録が行えること() {
-		Student student = Student.builder()
-				.fullName("田中太郎")
-				.furigana("タナカタロウ")
-				.nickname("たなか")
-				.emailAddress("rftgyhu@huji.com")
-				.address("東京")
-				.age(35)
-				.gender("男性")
-				.remark("")
-				.deleted(false)
-				.build();
-
-		sut.registerStudent(student);
+	void 受講生の登録が行えること() {
+		sut.registerStudent(createDefaultStudent());
 
 		List<Student> actual = sut.searchStudentsList();
-		assertThat(actual.size()).isEqualTo(5);
+		assertThat(actual.size()).isEqualTo(6);
+	}
 
+	@Test
+	void 受講生情報の更新が行えること() {
+		Student initialStudent = createDefaultStudent();
+		sut.registerStudent(initialStudent);
+		int studentIdToUpdate = initialStudent.getId();
+		Student demoStudent = sut.searchStudent(studentIdToUpdate);
+		demoStudent.setDeleted(true);
+
+		sut.updateStudent(demoStudent);
+		Student updatedStudent = sut.searchStudent(studentIdToUpdate);
+
+
+		assertThat(updatedStudent.isDeleted()).isTrue();
+	}
+
+	//ヘルパーメソッド
+	private Student createDefaultStudent() {
+		return Student.builder()
+				.fullName("デフォルト太郎")
+				.furigana("デフォルトタロウ")
+				.nickname("デモニック")
+				.emailAddress("default.test@example.com")
+				.address("東京都千代田区")
+				.age(25)
+				.gender("男性")
+				.remark("デフォルトデータ")
+				.isDeleted(false)
+				.build();
 	}
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,12 @@
+spring.application.name=TaskStudentsManagement
+spring.sql.init.mode=always
+# MySQL
+spring.datasource.url=jdbc:h2:~/MODE=MySQL
+spring.datasource.username=sa
+spring.datasource.password=sa
+spring.datasource.driver-class-name=org.h2.Driver
+spring.h2.console.enabled=true
+# MyBatis
+mybatis.configuration.map-underscore-to-camel-case=true
+mybatis.mapper-locations=classpath*:/mapper/*.xml
+mybatis.type-aliases-package=raisetechtask.taskstudentsmanagement.finalversion.data

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -1,0 +1,15 @@
+
+INSERT INTO students (full_name, furigana, nickname, email_address, address, age, gender, remark, is_deleted) VALUES
+('山田 太郎', 'ヤマダ タロウ', 'タロウ', 'taro.yamada@example.com', '東京都渋谷区', 20, '男性', NULL, FALSE),
+('鈴木 花子', 'スズキ ハナコ', 'ハナ', 'hanako.suzuki@example.com', '大阪府大阪市', 22, '女性', 'Javaコース受講予定', FALSE),
+('佐藤 健太', 'サトウ ケンタ', NULL, 'kenta.sato@example.com', '福岡県福岡市', 25, '男性', NULL, FALSE),
+('田中 美咲', 'タナカ ミサキ', 'ミサキ', 'misaki.tanaka@example.com', '愛知県名古屋市', 21, '女性', 'Python興味あり', FALSE),
+('高橋 雄一', 'タカハシ ユウイチ', NULL, 'yuichi.takahashi@example.com', '北海道札幌市', 23, '男性', 'Web開発コース検討中', FALSE);
+
+
+INSERT INTO students_courses (student_id, course_name, course_start_day, course_completion_day) VALUES
+(1, 'Java基礎', '2024-04-01', '2024-06-30'),
+(1, 'Spring Boot実践', '2024-07-15', '2024-09-30'),
+(2, 'データサイエンス入門', '2024-05-10', '2024-08-10'),
+(3, 'SQLデータベース', '2024-06-01', '2024-07-31'),
+(4, 'フロントエンド開発', '2024-04-20', '2024-09-20');

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -9,7 +9,14 @@ INSERT INTO students (full_name, furigana, nickname, email_address, address, age
 
 INSERT INTO students_courses (student_id, course_name, course_start_day, course_completion_day) VALUES
 (1, 'Java基礎', '2024-04-01', '2024-06-30'),
-(1, 'Spring Boot実践', '2024-07-15', '2024-09-30'),
+(5, 'Spring Boot実践', '2024-07-15', '2024-09-30'),
 (2, 'データサイエンス入門', '2024-05-10', '2024-08-10'),
 (3, 'SQLデータベース', '2024-06-01', '2024-07-31'),
 (4, 'フロントエンド開発', '2024-04-20', '2024-09-20');
+
+INSERT INTO application_status (student_course_id, status) VALUES
+(101, 'KARI_MOSIKOMI'),
+(999, 'HON_MOSIKOMI'),
+(103, 'JUKOCHU'),
+(104, 'JUKO_SHURYO'),
+(105, 'KARI_MOSIKOMI');

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS students
+(
+    id int NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    full_name VARCHAR(100) NOT NULL,
+    furigana VARCHAR(100) NOT NULL,
+    nickname VARCHAR(50),
+    email_address VARCHAR(100) NOT NULL,
+    address VARCHAR(150) NOT NULL,
+    age int NOT NULL,
+    gender VARCHAR(10) NOT NULL,
+    remark  VARCHAR(250),
+    is_deleted boolean NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS students_courses
+(
+    id int NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    student_id int NOT NULL,
+    course_name VARCHAR(50) NOT NULL,
+    course_start_day DATE NOT NULL,
+    course_completion_day DATE NOT NULL
+);

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -20,3 +20,11 @@ CREATE TABLE IF NOT EXISTS students_courses
     course_start_day DATE NOT NULL,
     course_completion_day DATE NOT NULL
 );
+
+
+CREATE TABLE IF NOT EXISTS application_status
+(
+    id INT AUTO_INCREMENT NOT NULL PRIMARY KEY,
+    student_course_id INT NOT NULL UNIQUE,
+    status VARCHAR(50) NOT NULL
+);


### PR DESCRIPTION
## 概要
課題44作成中です。DB設計後repositoryを作成。repositoryのテストを実装しています。
```
データ変換中にエラーが発生しました "JUKOCHU"
Data conversion error converting "JUKOCHU"; SQL statement:
UPDATE application_status SET status = ?
        WHERE id = ? [22018-232]
```
このエラー解決ができない状態です

## 実施した内容
Test側でのデバック処理
![image](https://github.com/user-attachments/assets/446a7c13-b919-4ad9-829b-96db7b08bc3a)
int update = statusSut.updateStatus(updateDemoStatus);（94行）でブレイクポイント設定した結果となります。
各項目に値は適切に入っており処理としては問題ないと考えています。

xmlにてSET　statusを#{status.displayValue, jdbcType=VARCHAR}と明示

## 質問
AIに聞いたところMyBatisのparameterTypeがEnumの時のデフォルト挙動が原因であり#{status.displayValue}と明示してもうまく動かないことがある。
対策としてMapを使用するかtypehandlerの作成案を出しているのですが、それが正しいのか、現状で改善できることが他にないのかわからない状態です。